### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Generates a Miro OAuth authorization URL for obtaining access tokens.
 }
 ```
 
+### `test_miro_token`
+Tests if a Miro access token is valid and working.
+
+**Input:**
+```json
+{
+  "accessToken": "your_miro_access_token"
+}
+```
+
 ### `create_miro_board`
 Creates a Miro board with Learning Hour content automatically laid out.
 
@@ -121,14 +131,38 @@ npm run test:integration
 
 ## Miro Integration Workflow
 
-### Option 1: Direct Integration (Recommended)
+### Getting a Miro Access Token
 
-1. **Get Miro Authorization URL**:
+To use Miro integration, you need a valid access token. Here are two ways:
+
+#### Option A: Quick Personal Access Token (Easiest)
+1. Go to [Miro Developer Portal](https://developers.miro.com/reference/oauth-2.0)
+2. Create a developer account
+3. Create a new app
+4. Generate a personal access token
+5. Test it: `test_miro_token {"accessToken": "your_token"}`
+
+#### Option B: OAuth Flow (For Production)
+1. **Get Authorization URL**:
 ```json
 {
   "tool": "get_miro_auth_url",
   "arguments": {
     "redirectUri": "http://localhost:3000/callback"
+  }
+}
+```
+
+2. Visit the URL, authorize, and exchange the code for a token
+
+### Using Miro Integration
+
+1. **Test Your Token**:
+```json
+{
+  "tool": "test_miro_token",
+  "arguments": {
+    "accessToken": "your_miro_access_token"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that generates comprehensive Learning Hour content for Technical Coaches, enabling teams to practice technical excellence through structured deliberate practice sessions. Works seamlessly with the Miro MCP for creating interactive boards.
 
+<a href="https://glama.ai/mcp/servers/@SDiamante13/learning-hour-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@SDiamante13/learning-hour-mcp/badge" alt="Learning Hour MCP server" />
+</a>
+
 ## Philosophy
 
 Learning Hours are structured practice sessions where software teams develop technical excellence skills through deliberate practice. Just as athletes and pilots dedicate time to practice their craft, software developers need dedicated time to master fundamental programming practices that stand the test of time.

--- a/src/MiroIntegration.ts
+++ b/src/MiroIntegration.ts
@@ -123,6 +123,7 @@ export class MiroIntegration {
   async createStickyNote(boardId: string, content: string, x: number, y: number, color: string = 'light_yellow'): Promise<MiroStickyNote> {
     try {
       const response = await axios.post(`${this.miroApiUrl}/boards/${boardId}/items`, {
+        type: 'sticky_note',
         data: {
           content: content,
           shape: 'square'
@@ -150,9 +151,9 @@ export class MiroIntegration {
   async createTextFrame(boardId: string, content: string, x: number, y: number, width: number = 400, height: number = 200): Promise<MiroTextFrame> {
     try {
       const response = await axios.post(`${this.miroApiUrl}/boards/${boardId}/items`, {
+        type: 'text',
         data: {
-          content: content,
-          format: 'html'
+          content: content
         },
         style: {
           fillColor: 'transparent',

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,20 @@ class LearningHourMCP {
             required: ["redirectUri"],
           },
         },
+        {
+          name: "test_miro_token",
+          description: "Test if a Miro access token is valid",
+          inputSchema: {
+            type: "object",
+            properties: {
+              accessToken: {
+                type: "string",
+                description: "Miro access token to test",
+              },
+            },
+            required: ["accessToken"],
+          },
+        },
       ],
     }));
 
@@ -140,6 +154,8 @@ class LearningHourMCP {
             return await this.createMiroBoard(request.params.arguments);
           case "get_miro_auth_url":
             return await this.getMiroAuthUrl(request.params.arguments);
+          case "test_miro_token":
+            return await this.testMiroToken(request.params.arguments);
           default:
             throw new McpError(
               ErrorCode.MethodNotFound,
@@ -272,6 +288,44 @@ class LearningHourMCP {
       };
     } catch (error) {
       throw new Error(`Failed to generate Miro auth URL: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async testMiroToken(args: any) {
+    const { accessToken } = args;
+    
+    try {
+      const miro = new MiroIntegration(accessToken);
+      const isValid = await miro.validateToken();
+      
+      if (isValid) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `✅ Miro access token is valid and working`,
+            },
+          ],
+        };
+      } else {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `❌ Miro access token is invalid or expired`,
+            },
+          ],
+        };
+      }
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `❌ Error testing Miro token: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
     }
   }
 


### PR DESCRIPTION
This PR adds a badge for the [Learning Hour MCP](https://glama.ai/mcp/servers/@SDiamante13/learning-hour-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@SDiamante13/learning-hour-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@SDiamante13/learning-hour-mcp/badge" alt="Learning Hour MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.